### PR TITLE
chore: use Eldertree self-hosted runners

### DIFF
--- a/.github/workflows/pr-issue-update.yml
+++ b/.github/workflows/pr-issue-update.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   update-issues:
     name: Update Linked Issues and Project Status
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.event.pull_request.state == 'closed'
 
     steps:

--- a/.github/workflows/pr-issue-update.yml
+++ b/.github/workflows/pr-issue-update.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   update-issues:
     name: Update Linked Issues and Project Status
-    runs-on: self-hosted
+    runs-on: ['self-hosted']
     if: github.event.pull_request.state == 'closed'
 
     steps:


### PR DESCRIPTION
Switch inline workflow jobs from `ubuntu-latest` to `self-hosted` (ARC on K3s). Requires pi-fleet org-wide ARC + github-workflows defaults.

Made with [Cursor](https://cursor.com)